### PR TITLE
Removed unnecesary read-string from twins example.

### DIFF
--- a/src/clojinc/core.clj
+++ b/src/clojinc/core.clj
@@ -1995,9 +1995,9 @@ X
 (defn print-twins
   [[this that]] 
   (println "the first twin is" 
-           (read-string (name this))
+           (name this)
            "and the other is" 
-           (read-string (name that)))) 
+           (name that)))
 
 ; #'clojinc.core/print-twins
 


### PR DESCRIPTION
No rush on this. But, it didn't seem like `read-string` was necessary in this example, and might confuse someone.
